### PR TITLE
Bug fix for gTLD registrar validation

### DIFF
--- a/lib/rdap-validator.js
+++ b/lib/rdap-validator.js
@@ -1557,7 +1557,7 @@ self.validateCommonGTLDResponseProperties = function(response) {
             "icann_rdap_response_profile_1",
             "icann_rdap_technical_implementation_guide_1"
         ].forEach((s) => self.add(
-            response.rdapConformance.includes(),
+            response.rdapConformance.includes(s),
             "The 'rdapConformance' array MUST include '" + s + "'."
         ));
 
@@ -1831,7 +1831,7 @@ self.validateCommonGTLDDomainProperties = function(domain, name) {
                         l.hasOwnProperty("rel") &&
                         "glossary" === l.rel &&
                         l.hasOwnProperty("href") &&
-                        "https://icann.org/epp" === n.href
+                        "https://icann.org/epp" === l.href
                     ).length > 0
             ).length,
             "Domain object MUST contain a 'Status Codes' notice containing a link with rel=glossary and href=https://icann.org/epp.",
@@ -1849,7 +1849,7 @@ self.validateCommonGTLDDomainProperties = function(domain, name) {
                     l.hasOwnProperty("rel") &&
                     "help" === l.rel &&
                     l.hasOwnProperty("href") &&
-                    "https://icann.org/wicf" === n.href
+                    "https://icann.org/wicf" === l.href
                 ).length > 0
             ).length,
             "Domain object MUST contain a 'RDDS Inaccuracy Complaint Form' notice containing a link with rel=help and href=https://icann.org/wicf.",


### PR DESCRIPTION
Hey! I was using this tool earlier to validate a few changes I am making with our implementation (it's much easier to use than the previous Java version) and came across a few bugs in the gTLD registrar profile.

1. Fixed link validation to correctly use the link href value rather than the notice object
2. The RDAP conformance validation wasn't properly passing in the expected strings so it was always returning invalid 