### PR TITLE
Fix registrar entity vcard validation error

### DIFF
--- a/lib/rdap-validator.js
+++ b/lib/rdap-validator.js
@@ -2357,7 +2357,7 @@ self.validateGTLDEntity = function(rar) {
         self.iterate(
             rar.vcardArray[1],
             function (p) {
-                if (self.isArray(p) && self.isString(p[1])) {
+                if (self.isArray(p) && self.isString(p[0])) {
                     seen_types[p[0].toUpperCase()] = 1;
 
                     if ("ADR" == p[0].toUpperCase()) {


### PR DESCRIPTION
We were getting a false positive when validating RDAP registrar entity for the registry profile.

The problem is that second element of vcard row, is normally an object and not a string. The intent of the original code was to check the name which is element 0.